### PR TITLE
Restructured publications and added project resources

### DIFF
--- a/src/data/projectResources.ts
+++ b/src/data/projectResources.ts
@@ -1,0 +1,60 @@
+import {
+  getPublications,
+  stripAuthorFormatting,
+} from "@/data/publications";
+
+export interface ProjectResource {
+  id: string;
+  title: string;
+  url: string;
+  details?: string;
+  linkText?: string;
+  publishedOn: string;
+}
+
+interface ExternalProjectResource extends ProjectResource {
+  projectId: string;
+}
+
+const externalProjectResources: ExternalProjectResource[] = [
+  // Add non-publication resources here (e.g., external papers, blog posts, videos).
+  // {
+  //   id: "example-resource-id",
+  //   projectId: "exploring-endless-worlds-vr",
+  //   title: "Example resource title",
+  //   url: "https://example.com",
+  //   details: "Optional short context",
+  //   linkText: "Open Resource",
+  //   publishedOn: "2025-01-01",
+  // },
+];
+
+function toTimestamp(dateString: string): number {
+  const timestamp = Date.parse(dateString);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+export function getProjectTalksAndResources(projectId: string): ProjectResource[] {
+  const exhibitionResources = getPublications({
+    category: "Exhibitions, Presentations, and Posters",
+    projectId,
+    authoredByProfileOnly: true,
+  }).map((publication) => ({
+    id: publication.id,
+    title: publication.title,
+    url: publication.linkUrl,
+    details: [stripAuthorFormatting(publication.authors), publication.venue]
+      .filter(Boolean)
+      .join(" "),
+    linkText: publication.linkText,
+    publishedOn: publication.publishedOn,
+  }));
+
+  const additionalResources = externalProjectResources.filter(
+    (resource) => resource.projectId === projectId,
+  );
+
+  return [...exhibitionResources, ...additionalResources].sort(
+    (a, b) => toTimestamp(b.publishedOn) - toTimestamp(a.publishedOn),
+  );
+}

--- a/src/data/publications.ts
+++ b/src/data/publications.ts
@@ -1,152 +1,338 @@
+export const publicationCategories = [
+  "Peer-Reviewed Journals",
+  "Other Peer-Reviewed Publications",
+  "Exhibitions, Presentations, and Posters",
+] as const;
+
+export type PublicationCategory = (typeof publicationCategories)[number];
+
 export interface Publication {
   id: string;
   title: string;
   authors: string;
   venue: string;
   linkText: string;
-  linkUrl: string; // Placeholder or actual link if provided
-  category: 'Peer-Reviewed Journals' | 'Other Peer-Reviewed Publications' | 'Exhibitions, Presentations, and Posters';
+  linkUrl: string;
+  category: PublicationCategory;
+  publishedOn: string;
+  relatedProjectIds: string[];
 }
 
+export interface ProjectPublication {
+  id: string;
+  title: string;
+  authors: string;
+  venue: string;
+  link: string;
+  linkText: string;
+  publishedOn: string;
+}
+
+const PROFILE_AUTHOR_PATTERN = /\badhikari\b/i;
+
+export function stripAuthorFormatting(authors: string): string {
+  return authors.replace(/\*\*/g, "");
+}
+
+function toTimestamp(dateString: string): number {
+  const timestamp = Date.parse(dateString);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function sortByPublishedOnDesc<T extends { publishedOn: string }>(items: T[]): T[] {
+  return [...items].sort(
+    (a, b) => toTimestamp(b.publishedOn) - toTimestamp(a.publishedOn),
+  );
+}
+
+export function isProfileAuthoredPublication(publication: Publication): boolean {
+  return PROFILE_AUTHOR_PATTERN.test(stripAuthorFormatting(publication.authors));
+}
+
+// For each new entry, set `publishedOn` (ISO date) and `relatedProjectIds`.
+// If authors include "Adhikari", it will appear in profile publication/project listings.
 export const publicationsData: Publication[] = [
   // Peer-Reviewed Journals
   {
-    id: 'journal-1',
-    title: 'Leaning-based interfaces improve simultaneous locomotion and object interaction in VR compared to the handheld controller.',
-    authors: 'Hashemian, A.M., **Adhikari, A.**, Aguilar, I.A., Kruij, E., von der Heyde, M., & Riecke, B.E.',
-    venue: 'IEEE Transactions on Visualization and Computer Graphics, 30(8), 4665-4682 (2024).',
-    linkText: 'View Publication',
-    linkUrl: 'https://doi.org/10.1109/TVCG.2023.3275111',
-    category: 'Peer-Reviewed Journals'
+    id: "journal-1",
+    title:
+      "Leaning-based interfaces improve simultaneous locomotion and object interaction in VR compared to the handheld controller.",
+    authors:
+      "Hashemian, A.M., **Adhikari, A.**, Aguilar, I.A., Kruij, E., von der Heyde, M., & Riecke, B.E.",
+    venue:
+      "IEEE Transactions on Visualization and Computer Graphics, 30(8), 4665-4682 (2024).",
+    linkText: "View Publication",
+    linkUrl: "https://doi.org/10.1109/TVCG.2023.3275111",
+    category: "Peer-Reviewed Journals",
+    publishedOn: "2024-01-01",
+    relatedProjectIds: ["exploring-endless-worlds-vr"],
   },
   {
-    id: 'journal-2',
-    title: 'Integrating continuous and teleporting VR locomotion into a seamless \'hyperjump\' paradigm.',
-    authors: '**Adhikari, A.**, Zielasko, D., Aguilar, I., Bretin, A., Kruij, E., von der Heyde, M., & Riecke, B.E.',
-    venue: 'IEEE Transactions on Visualization and Computer Graphics, 29(12), 5265-5281 (2022).',
-    linkText: 'View Publication',
-    linkUrl: 'https://ieeexplore.ieee.org/abstract/document/9894041/',
-    category: 'Peer-Reviewed Journals'
+    id: "journal-2",
+    title:
+      "Integrating continuous and teleporting VR locomotion into a seamless 'hyperjump' paradigm.",
+    authors:
+      "**Adhikari, A.**, Zielasko, D., Aguilar, I., Bretin, A., Kruij, E., von der Heyde, M., & Riecke, B.E.",
+    venue:
+      "IEEE Transactions on Visualization and Computer Graphics, 29(12), 5265-5281 (2022).",
+    linkText: "View Publication",
+    linkUrl: "https://ieeexplore.ieee.org/abstract/document/9894041/",
+    category: "Peer-Reviewed Journals",
+    publishedOn: "2022-01-01",
+    relatedProjectIds: ["exploring-endless-worlds-vr", "vr-beyond-ordinary"],
   },
   {
-    id: 'journal-3',
-    title: 'Lean to fly: Leaning-based embodied flying can improve performance and user experience in 3D navigation.',
-    authors: '**Adhikari, A.**, Hashemian, A.M., Nguyen-Vo, T., Kruij, E., von der Heyde, M., & Riecke, B.E.',
-    venue: 'Frontiers in Virtual Reality, 2, 730334 (2021).',
-    linkText: 'View Publication',
-    linkUrl: 'https://www.frontiersin.org/articles/10.3389/frvir.2021.730334/full',
-    category: 'Peer-Reviewed Journals'
+    id: "journal-3",
+    title:
+      "Lean to fly: Leaning-based embodied flying can improve performance and user experience in 3D navigation.",
+    authors:
+      "**Adhikari, A.**, Hashemian, A.M., Nguyen-Vo, T., Kruij, E., von der Heyde, M., & Riecke, B.E.",
+    venue: "Frontiers in Virtual Reality, 2, 730334 (2021).",
+    linkText: "View Publication",
+    linkUrl:
+      "https://www.frontiersin.org/articles/10.3389/frvir.2021.730334/full",
+    category: "Peer-Reviewed Journals",
+    publishedOn: "2021-08-19",
+    relatedProjectIds: ["exploring-endless-worlds-vr"],
   },
   {
-    id: 'journal-4',
-    title: 'Leaning-based interfaces improve ground-based VR locomotion in reach-the-target, follow-the-path, and racing tasks.',
-    authors: 'Hashemian, A.M., **Adhikari, A.**, Kruij, E., von der Heyde, M., & Riecke, B.E.',
-    venue: 'IEEE Transactions on Visualization and Computer Graphics, 29(3), 1748-1768 (2021).',
-    linkText: 'View Publication',
-    linkUrl: 'https://doi.org/10.1109/TVCG.2021.3131422',
-    category: 'Peer-Reviewed Journals'
+    id: "journal-4",
+    title:
+      "Leaning-based interfaces improve ground-based VR locomotion in reach-the-target, follow-the-path, and racing tasks.",
+    authors:
+      "Hashemian, A.M., **Adhikari, A.**, Kruij, E., von der Heyde, M., & Riecke, B.E.",
+    venue:
+      "IEEE Transactions on Visualization and Computer Graphics, 29(3), 1748-1768 (2021).",
+    linkText: "View Publication",
+    linkUrl: "https://doi.org/10.1109/TVCG.2021.3131422",
+    category: "Peer-Reviewed Journals",
+    publishedOn: "2021-01-01",
+    relatedProjectIds: ["exploring-endless-worlds-vr"],
   },
   {
-    id: 'journal-5',
-    title: 'HeadJoystick: Improving flying in VR using a novel leaning-based interface.',
-    authors: 'Hashemian, A.M., Lotfaliei, M., **Adhikari, A.**, Kruij, E., & Riecke, B.E.',
-    venue: 'IEEE Transactions on Visualization and Computer Graphics, 28(4), 1792-1809 (2020).',
-    linkText: 'View Publication',
-    linkUrl: 'https://doi.org/10.1109/TVCG.2020.3025084',
-    category: 'Peer-Reviewed Journals'
+    id: "journal-5",
+    title:
+      "HeadJoystick: Improving flying in VR using a novel leaning-based interface.",
+    authors:
+      "Hashemian, A.M., Lotfaliei, M., **Adhikari, A.**, Kruij, E., & Riecke, B.E.",
+    venue:
+      "IEEE Transactions on Visualization and Computer Graphics, 28(4), 1792-1809 (2020).",
+    linkText: "View Publication",
+    linkUrl: "https://doi.org/10.1109/TVCG.2020.3025084",
+    category: "Peer-Reviewed Journals",
+    publishedOn: "2020-01-01",
+    relatedProjectIds: ["exploring-endless-worlds-vr"],
   },
 
   // Other Peer-Reviewed Publications
   {
-    id: 'conf-1',
-    title: "'I Call Upon a Friend': Virtual Reality-Based Supports for Cognitive Reappraisal Identified through Co-designing with Adolescents.",
-    authors: 'Kitson, A., Antle, A.N., Kenny, S., **Adhikari, A.**, Karthik, K., Cimensel, A., & Chan, M.',
-    venue: 'Proceedings of CHI 2024, ACM, Article 691, 1-18.',
-    linkText: 'View Publication',
-    linkUrl: 'https://doi.org/10.1145/3613904.3642723',
-    category: 'Other Peer-Reviewed Publications'
+    id: "conf-1",
+    title:
+      "'I Call Upon a Friend': Virtual Reality-Based Supports for Cognitive Reappraisal Identified through Co-designing with Adolescents.",
+    authors:
+      "Kitson, A., Antle, A.N., Kenny, S., **Adhikari, A.**, Karthik, K., Cimensel, A., & Chan, M.",
+    venue: "Proceedings of CHI 2024, ACM, Article 691, 1-18.",
+    linkText: "View Publication",
+    linkUrl: "https://doi.org/10.1145/3613904.3642723",
+    category: "Other Peer-Reviewed Publications",
+    publishedOn: "2024-05-11",
+    relatedProjectIds: ["master-emotions-vr"],
   },
   {
-    id: 'conf-2',
-    title: 'Awedyssey: Design tensions in eliciting self-transcendent emotions in virtual reality to support mental well-being and connection.',
-    authors: 'Miller, N., Stepanova, E.R., Desnoyers-Stewart, J., **Adhikari, A.**, Kitson, A., et al.',
-    venue: 'Proceedings of the 2023 ACM Designing Interactive Systems Conference, 189-211.',
-    linkText: 'View Publication',
-    linkUrl: 'https://doi.org/10.1145/3563657.3595998',
-    category: 'Other Peer-Reviewed Publications'
+    id: "conf-2",
+    title:
+      "Awedyssey: Design tensions in eliciting self-transcendent emotions in virtual reality to support mental well-being and connection.",
+    authors:
+      "Miller, N., Stepanova, E.R., Desnoyers-Stewart, J., **Adhikari, A.**, Kitson, A., et al.",
+    venue:
+      "Proceedings of the 2023 ACM Designing Interactive Systems Conference, 189-211.",
+    linkText: "View Publication",
+    linkUrl: "https://doi.org/10.1145/3563657.3595998",
+    category: "Other Peer-Reviewed Publications",
+    publishedOn: "2023-07-10",
+    relatedProjectIds: ["master-emotions-vr"],
   },
   {
-    id: 'conf-3',
-    title: 'FeetBack: Augmenting robotic telepresence with haptic feedback on the feet.',
-    authors: 'Jones, B., Maiero, J., Mogharrab, A., Aguilar, I.A., **Adhikari, A.**, Riecke, B.E., Kruij, E., Neustaedter, C., & Lindeman, R.W.',
-    venue: 'Proceedings of ICMI 2020, 194-203.',
-    linkText: 'View Publication',
-    linkUrl: 'https://doi.org/10.1145/3382507.3418820',
-    category: 'Other Peer-Reviewed Publications'
+    id: "conf-3",
+    title: "FeetBack: Augmenting robotic telepresence with haptic feedback on the feet.",
+    authors:
+      "Jones, B., Maiero, J., Mogharrab, A., Aguilar, I.A., **Adhikari, A.**, Riecke, B.E., Kruij, E., Neustaedter, C., & Lindeman, R.W.",
+    venue: "Proceedings of ICMI 2020, 194-203.",
+    linkText: "View Publication",
+    linkUrl: "https://doi.org/10.1145/3382507.3418820",
+    category: "Other Peer-Reviewed Publications",
+    publishedOn: "2020-10-25",
+    relatedProjectIds: [],
   },
 
   // Exhibitions, Presentations, and Posters
   {
-    id: 'exhibit-1',
-    title: 'Awedyssey [Curated Mixed Reality Exhibition].',
-    authors: 'Miller, N., Desnoyers-Stewart, J., Stepanova, E. R., **Adhikari, A.**, Riecke, B. E., Pennefather, P. P., Kitson, A., & Quesnel, D.',
-    venue: 'Cosmic Nights: Humans in Space, H.R. MacMillan Space Centre, November 23, 2023.',
-    linkText: 'More Details',
-    linkUrl: 'https://events.sfu.ca/event/37966-cosmic-nights-humans-in-space',
-    category: 'Exhibitions, Presentations, and Posters'
+    id: "exhibit-1",
+    title: "Awedyssey [Curated Mixed Reality Exhibition].",
+    authors:
+      "Miller, N., Desnoyers-Stewart, J., Stepanova, E. R., **Adhikari, A.**, Riecke, B. E., Pennefather, P. P., Kitson, A., & Quesnel, D.",
+    venue:
+      "Cosmic Nights: Humans in Space, H.R. MacMillan Space Centre, November 23, 2023.",
+    linkText: "More Details",
+    linkUrl: "https://events.sfu.ca/event/37966-cosmic-nights-humans-in-space",
+    category: "Exhibitions, Presentations, and Posters",
+    publishedOn: "2023-11-23",
+    relatedProjectIds: ["master-emotions-vr"],
   },
   {
-    id: 'exhibit-2',
-    title: 'HyperJumping in Virtual Vancouver: Combating motion sickness by merging teleporting and continuous VR locomotion in an embodied hands-free VR flying paradigm.',
-    authors: 'Riecke, B. E., Clement, D., **Adhikari, A.**, Quesnel, D., Zielasko, D., & von der Heyde, M.',
-    venue: '',
-    linkText: 'View Abstract',
-    linkUrl: 'https://doi.org/10.1145/3532834.3536211',
-    category: 'Exhibitions, Presentations, and Posters'
+    id: "exhibit-2",
+    title:
+      "HyperJumping in Virtual Vancouver: Combating motion sickness by merging teleporting and continuous VR locomotion in an embodied hands-free VR flying paradigm.",
+    authors:
+      "Riecke, B. E., Clement, D., **Adhikari, A.**, Quesnel, D., Zielasko, D., & von der Heyde, M.",
+    venue: "",
+    linkText: "View Abstract",
+    linkUrl: "https://doi.org/10.1145/3532834.3536211",
+    category: "Exhibitions, Presentations, and Posters",
+    publishedOn: "2022-06-01",
+    relatedProjectIds: ["exploring-endless-worlds-vr", "vr-beyond-ordinary"],
   },
   {
-    id: 'exhibit-3',
-    title: 'Embodied VR flying improves spatial orientation while reducing cybersickness.',
-    authors: '**Adhikari, A.**, Riecke, B.E., Hashemian, A.M., Nguyen-Vo, T., Kruij, E., & von der Heyde, M.',
-    venue: 'Talk presented at ICSC 2021, Rome, Italy.',
-    linkText: 'Watch Presentation',
-    linkUrl: 'https://www.youtube.com/watch?v=FbmE4SEISWU',
-    category: 'Exhibitions, Presentations, and Posters'
+    id: "exhibit-3",
+    title:
+      "Embodied VR flying improves spatial orientation while reducing cybersickness.",
+    authors:
+      "**Adhikari, A.**, Riecke, B.E., Hashemian, A.M., Nguyen-Vo, T., Kruij, E., & von der Heyde, M.",
+    venue: "Talk presented at ICSC 2021, Rome, Italy.",
+    linkText: "Watch Presentation",
+    linkUrl: "https://www.youtube.com/watch?v=FbmE4SEISWU",
+    category: "Exhibitions, Presentations, and Posters",
+    publishedOn: "2021-09-13",
+    relatedProjectIds: ["exploring-endless-worlds-vr"],
   },
   {
-    id: 'exhibit-4',
-    title: 'HyperJump: Merging Teleporting and Continuous VR Locomotion into One Paradigm.',
-    authors: 'Riecke, B.E., **Adhikari, A.**, Zielasko, D., Bretin, A., von der Heyde, M., and Kruij, E.',
-    venue: 'Talk presented at ICSC 2021, Rome, Italy.',
-    linkText: 'Watch Presentation',
-    linkUrl: 'https://www.youtube.com/watch?v=hRqkqup40bI',
-    category: 'Exhibitions, Presentations, and Posters'
+    id: "exhibit-4",
+    title:
+      "HyperJump: Merging Teleporting and Continuous VR Locomotion into One Paradigm.",
+    authors:
+      "Riecke, B.E., **Adhikari, A.**, Zielasko, D., Bretin, A., von der Heyde, M., and Kruij, E.",
+    venue: "Talk presented at ICSC 2021, Rome, Italy.",
+    linkText: "Watch Presentation",
+    linkUrl: "https://www.youtube.com/watch?v=hRqkqup40bI",
+    category: "Exhibitions, Presentations, and Posters",
+    publishedOn: "2021-09-13",
+    relatedProjectIds: ["exploring-endless-worlds-vr"],
   },
   {
-    id: 'exhibit-5',
-    title: 'Integrating Continuous and Teleporting VR Locomotion into a Seamless \'HyperJump\' Paradigm.',
-    authors: '**Adhikari, A.**, Zielasko, D., Bretin, A., von der Heyde, M., Kruij, E., & Riecke, B.E.',
-    venue: 'IEEE VR 2021 Workshop, 370-372.',
-    linkText: 'View Abstract',
-    linkUrl: 'https://doi.org/10.1109/VRW52623.2021.00074',
-    category: 'Exhibitions, Presentations, and Posters'
+    id: "exhibit-5",
+    title:
+      "Integrating Continuous and Teleporting VR Locomotion into a Seamless 'HyperJump' Paradigm.",
+    authors:
+      "**Adhikari, A.**, Zielasko, D., Bretin, A., von der Heyde, M., Kruij, E., & Riecke, B.E.",
+    venue: "IEEE VR 2021 Workshop, 370-372.",
+    linkText: "View Abstract",
+    linkUrl: "https://doi.org/10.1109/VRW52623.2021.00074",
+    category: "Exhibitions, Presentations, and Posters",
+    publishedOn: "2021-03-27",
+    relatedProjectIds: ["exploring-endless-worlds-vr"],
   },
   {
-    id: 'exhibit-6',
-    title: 'Simultaneous Locomotion and Interaction in VR: Walking > Leaning > Controller.',
-    authors: 'Riecke, B.E., Hashemian, A.M., **Adhikari, A.**, Aguilar, I., Kruijff, E., & von der Heyde, M.',
-    venue: 'ICSC 2021: 8th International Conference on Spatial Cognition, Rome, Italy.',
-    linkText: 'Watch Presentation',
-    linkUrl: 'https://www.youtube.com/watch?v=jzoaBAd6gPY',
-    category: 'Exhibitions, Presentations, and Posters'
+    id: "exhibit-6",
+    title: "Simultaneous Locomotion and Interaction in VR: Walking > Leaning > Controller.",
+    authors:
+      "Riecke, B.E., Hashemian, A.M., **Adhikari, A.**, Aguilar, I., Kruijff, E., & von der Heyde, M.",
+    venue:
+      "ICSC 2021: 8th International Conference on Spatial Cognition, Rome, Italy.",
+    linkText: "Watch Presentation",
+    linkUrl: "https://www.youtube.com/watch?v=jzoaBAd6gPY",
+    category: "Exhibitions, Presentations, and Posters",
+    publishedOn: "2021-09-13",
+    relatedProjectIds: ["exploring-endless-worlds-vr", "project-playground"],
   },
   {
-    id: 'exhibit-7',
-    title: 'SIRIUS [Curated & peer-reviewed Virtual Reality Exhibition]',
-    authors: 'Miller, N., Desnoyers-Stewart, J., Stepanova, E. R., **Adhikari, A.**, Riecke, B. E., Pennefather, P. P., Kitson, A., & Quesnel, D.',
-    venue: 'V-Unframed 2021, Vancouver, Canada.',
-    linkText: 'More Details',
-    linkUrl: 'https://www.alliancefrancaise.ca/v-unframed/en/the-artworks-2021/sirius/',
-    category: 'Exhibitions, Presentations, and Posters'
-  }
+    id: "exhibit-7",
+    title: "SIRIUS [Curated & peer-reviewed Virtual Reality Exhibition]",
+    authors:
+      "Miller, N., Desnoyers-Stewart, J., Stepanova, E. R., **Adhikari, A.**, Riecke, B. E., Pennefather, P. P., Kitson, A., & Quesnel, D.",
+    venue: "V-Unframed 2021, Vancouver, Canada.",
+    linkText: "More Details",
+    linkUrl:
+      "https://www.alliancefrancaise.ca/v-unframed/en/the-artworks-2021/sirius/",
+    category: "Exhibitions, Presentations, and Posters",
+    publishedOn: "2021-11-01",
+    relatedProjectIds: ["master-emotions-vr"],
+  },
 ];
+
+interface GetPublicationsOptions {
+  category?: PublicationCategory;
+  projectId?: string;
+  includeExhibitions?: boolean;
+  authoredByProfileOnly?: boolean;
+}
+
+export function getPublications(options: GetPublicationsOptions = {}): Publication[] {
+  const {
+    category,
+    projectId,
+    includeExhibitions = true,
+    authoredByProfileOnly = false,
+  } = options;
+
+  return sortByPublishedOnDesc(
+    publicationsData.filter((publication) => {
+      if (category && publication.category !== category) {
+        return false;
+      }
+
+      if (
+        !includeExhibitions &&
+        publication.category === "Exhibitions, Presentations, and Posters"
+      ) {
+        return false;
+      }
+
+      if (
+        projectId &&
+        !publication.relatedProjectIds.includes(projectId)
+      ) {
+        return false;
+      }
+
+      if (
+        authoredByProfileOnly &&
+        !isProfileAuthoredPublication(publication)
+      ) {
+        return false;
+      }
+
+      return true;
+    }),
+  );
+}
+
+export function getPublicationsByCategory(
+  authoredByProfileOnly = true,
+): Record<PublicationCategory, Publication[]> {
+  return publicationCategories.reduce(
+    (accumulator, category) => {
+      accumulator[category] = getPublications({
+        category,
+        authoredByProfileOnly,
+      });
+      return accumulator;
+    },
+    {} as Record<PublicationCategory, Publication[]>,
+  );
+}
+
+export function getProjectPublications(projectId: string): ProjectPublication[] {
+  return getPublications({
+    projectId,
+    includeExhibitions: false,
+    authoredByProfileOnly: true,
+  }).map((publication) => ({
+    id: publication.id,
+    title: publication.title,
+    authors: stripAuthorFormatting(publication.authors),
+    venue: publication.venue,
+    link: publication.linkUrl,
+    linkText: publication.linkText,
+    publishedOn: publication.publishedOn,
+  }));
+}

--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -1,12 +1,11 @@
-import { publicationsData } from "../data/publications";
+import {
+  getPublicationsByCategory,
+  publicationCategories,
+} from "../data/publications";
 import { Footer } from "@/components/Footer";
 
 export function Publications() {
-  const categories = [
-    "Peer-Reviewed Journals",
-    "Other Peer-Reviewed Publications",
-    "Exhibitions, Presentations, and Posters",
-  ] as const;
+  const publicationsByCategory = getPublicationsByCategory(true);
 
   const renderAuthors = (authors: string) => {
     const parts = authors.split("**");
@@ -35,10 +34,8 @@ export function Publications() {
         </h1>
 
         <div className="space-y-10 sm:space-y-12">
-          {categories.map((category) => {
-            const categoryPubs = publicationsData.filter(
-              (pub) => pub.category === category,
-            );
+          {publicationCategories.map((category) => {
+            const categoryPubs = publicationsByCategory[category];
 
             if (categoryPubs.length === 0) return null;
 

--- a/src/pages/projects/ExploringEndlessWorldsProjectPage.tsx
+++ b/src/pages/projects/ExploringEndlessWorldsProjectPage.tsx
@@ -1,9 +1,14 @@
 import { ProjectPageLayout } from "@/components/projects/ProjectPageLayout";
+import { getProjectPublications } from "@/data/publications";
+import { getProjectTalksAndResources } from "@/data/projectResources";
 import { getProjectById } from "@/data/projects";
 
-const project = getProjectById("exploring-endless-worlds-vr");
+const projectId = "exploring-endless-worlds-vr";
+const project = getProjectById(projectId);
 const hyperJumpTopViewGif =
   "/projects/exploring-endless-worlds/HyperJump_TopView.gif";
+const relatedPublications = getProjectPublications(projectId);
+const talksAndResources = getProjectTalksAndResources(projectId);
 
 export function ExploringEndlessWorldsProjectPage() {
   if (!project) return null;
@@ -34,94 +39,8 @@ export function ExploringEndlessWorldsProjectPage() {
             "Demonstration of HyperJump behavior in navigation and pointing tasks.",
         },
       ]}
-      talks={[
-        {
-          title:
-            "HyperJumping in Virtual Vancouver: Combating motion sickness by merging teleporting and continuous VR locomotion in an embodied hands-free VR flying paradigm.",
-          details:
-            "Riecke, B. E., Clement, D., Adhikari, A., Quesnel, D., Zielasko, D., & von der Heyde, M.",
-          url: "https://doi.org/10.1145/3532834.3536211",
-          linkText: "View Abstract",
-        },
-        {
-          title:
-            "Embodied VR flying improves spatial orientation while reducing cybersickness.",
-          details:
-            "Adhikari, A., Riecke, B.E., Hashemian, A.M., Nguyen-Vo, T., Kruij, E., & von der Heyde, M. Talk presented at ICSC 2021, Rome, Italy.",
-          url: "https://www.youtube.com/watch?v=FbmE4SEISWU",
-          linkText: "Watch Presentation",
-        },
-        {
-          title:
-            "HyperJump: Merging Teleporting and Continuous VR Locomotion into One Paradigm.",
-          details:
-            "Riecke, B.E., Adhikari, A., Zielasko, D., Bretin, A., von der Heyde, M., and Kruij, E. Talk presented at ICSC 2021, Rome, Italy.",
-          url: "https://www.youtube.com/watch?v=hRqkqup40bI",
-          linkText: "Watch Presentation",
-        },
-        {
-          title:
-            "Integrating Continuous and Teleporting VR Locomotion into a Seamless 'HyperJump' Paradigm.",
-          details:
-            "Adhikari, A., Zielasko, D., Bretin, A., von der Heyde, M., Kruij, E., & Riecke, B.E. IEEE VR 2021 Workshop, 370-372.",
-          url: "https://doi.org/10.1109/VRW52623.2021.00074",
-          linkText: "View Abstract",
-        },
-        {
-          title:
-            "Simultaneous Locomotion and Interaction in VR: Walking > Leaning > Controller.",
-          details:
-            "Riecke, B.E., Hashemian, A.M., Adhikari, A., Aguilar, I., Kruijff, E., & von der Heyde, M. ICSC 2021, Rome, Italy.",
-          url: "https://www.youtube.com/watch?v=jzoaBAd6gPY",
-          linkText: "Watch Presentation",
-        },
-      ]}
-      publications={[
-        {
-          title:
-            "Leaning-based interfaces improve simultaneous locomotion and object interaction in VR compared to the handheld controller.",
-          authors:
-            "Hashemian, A.M., Adhikari, A., Aguilar, I.A., Kruij, E., von der Heyde, M., & Riecke, B.E.",
-          venue:
-            "IEEE Transactions on Visualization and Computer Graphics, 30(8), 4665-4682 (2024).",
-          link: "https://doi.org/10.1109/TVCG.2023.3275111",
-        },
-        {
-          title:
-            "Integrating continuous and teleporting VR locomotion into a seamless 'hyperjump' paradigm.",
-          authors:
-            "Adhikari, A., Zielasko, D., Aguilar, I., Bretin, A., Kruij, E., von der Heyde, M., & Riecke, B.E.",
-          venue:
-            "IEEE Transactions on Visualization and Computer Graphics, 29(12), 5265-5281 (2022).",
-          link: "https://ieeexplore.ieee.org/abstract/document/9894041/",
-        },
-        {
-          title:
-            "Lean to fly: Leaning-based embodied flying can improve performance and user experience in 3D navigation.",
-          authors:
-            "Adhikari, A., Hashemian, A.M., Nguyen-Vo, T., Kruij, E., von der Heyde, M., & Riecke, B.E.",
-          venue: "Frontiers in Virtual Reality, 2, 730334 (2021).",
-          link: "https://www.frontiersin.org/articles/10.3389/frvir.2021.730334/full",
-        },
-        {
-          title:
-            "Leaning-based interfaces improve ground-based VR locomotion in reach-the-target, follow-the-path, and racing tasks.",
-          authors:
-            "Hashemian, A.M., Adhikari, A., Kruij, E., von der Heyde, M., & Riecke, B.E.",
-          venue:
-            "IEEE Transactions on Visualization and Computer Graphics, 29(3), 1748-1768 (2021).",
-          link: "https://doi.org/10.1109/TVCG.2021.3131422",
-        },
-        {
-          title:
-            "HeadJoystick: Improving flying in VR using a novel leaning-based interface.",
-          authors:
-            "Hashemian, A.M., Lotfaliei, M., Adhikari, A., Kruij, E., & Riecke, B.E.",
-          venue:
-            "IEEE Transactions on Visualization and Computer Graphics, 28(4), 1792-1809 (2020).",
-          link: "https://doi.org/10.1109/TVCG.2020.3025084",
-        },
-      ]}
+      talks={talksAndResources}
+      publications={relatedPublications}
     >
       <section className="space-y-4">
         <h2 className="text-primary">What This Research Focuses On</h2>

--- a/src/pages/projects/MasterYourEmotionsProjectPage.tsx
+++ b/src/pages/projects/MasterYourEmotionsProjectPage.tsx
@@ -1,7 +1,10 @@
 import { ProjectPageLayout } from "@/components/projects/ProjectPageLayout";
+import { getProjectPublications } from "@/data/publications";
 import { getProjectById } from "@/data/projects";
 
-const project = getProjectById("master-emotions-vr");
+const projectId = "master-emotions-vr";
+const project = getProjectById(projectId);
+const relatedPublications = getProjectPublications(projectId);
 
 export function MasterYourEmotionsProjectPage() {
   if (!project) return null;
@@ -13,25 +16,7 @@ export function MasterYourEmotionsProjectPage() {
       year={project.year}
       tags={project.tags}
       heroImage={project.image}
-      publications={[
-        {
-          title:
-            "'I Call Upon a Friend': Virtual Reality-Based Supports for Cognitive Reappraisal Identified through Co-designing with Adolescents.",
-          authors:
-            "Kitson, A., Antle, A.N., Kenny, S., Adhikari, A., Karthik, K., Cimensel, A., & Chan, M.",
-          venue: "Proceedings of CHI 2024, ACM, Article 691, 1-18.",
-          link: "https://doi.org/10.1145/3613904.3642723",
-        },
-        {
-          title:
-            "Awedyssey: Design tensions in eliciting self-transcendent emotions in virtual reality to support mental well-being and connection.",
-          authors:
-            "Miller, N., Stepanova, E.R., Desnoyers-Stewart, J., Adhikari, A., Kitson, A., et al.",
-          venue:
-            "Proceedings of the 2023 ACM Designing Interactive Systems Conference, 189-211.",
-          link: "https://doi.org/10.1145/3563657.3595998",
-        },
-      ]}
+      publications={relatedPublications}
     >
       <section className="space-y-4">
         <h2 className="text-primary">Research Direction</h2>

--- a/src/pages/projects/ProjectPlaygroundProjectPage.tsx
+++ b/src/pages/projects/ProjectPlaygroundProjectPage.tsx
@@ -1,7 +1,10 @@
 import { ProjectPageLayout } from "@/components/projects/ProjectPageLayout";
+import { getProjectTalksAndResources } from "@/data/projectResources";
 import { getProjectById } from "@/data/projects";
 
-const project = getProjectById("project-playground");
+const projectId = "project-playground";
+const project = getProjectById(projectId);
+const talksAndResources = getProjectTalksAndResources(projectId);
 
 export function ProjectPlaygroundProjectPage() {
   if (!project) return null;
@@ -13,13 +16,7 @@ export function ProjectPlaygroundProjectPage() {
       year={project.year}
       tags={project.tags}
       heroImage={project.image}
-      talks={[
-        {
-          title:
-            "Simultaneous Locomotion and Interaction in VR: Walking > Leaning > Controller",
-          url: "https://www.youtube.com/watch?v=jzoaBAd6gPY",
-        },
-      ]}
+      talks={talksAndResources}
       emptyPublicationsText="This project acts as an incubator. Publications are usually linked from the downstream projects that emerge from this space."
     >
       <section className="space-y-4">

--- a/src/pages/projects/VrBeyondOrdinaryProjectPage.tsx
+++ b/src/pages/projects/VrBeyondOrdinaryProjectPage.tsx
@@ -1,7 +1,12 @@
 import { ProjectPageLayout } from "@/components/projects/ProjectPageLayout";
+import { getProjectPublications } from "@/data/publications";
+import { getProjectTalksAndResources } from "@/data/projectResources";
 import { getProjectById } from "@/data/projects";
 
-const project = getProjectById("vr-beyond-ordinary");
+const projectId = "vr-beyond-ordinary";
+const project = getProjectById(projectId);
+const relatedPublications = getProjectPublications(projectId);
+const talksAndResources = getProjectTalksAndResources(projectId);
 
 export function VrBeyondOrdinaryProjectPage() {
   if (!project) return null;
@@ -21,23 +26,8 @@ export function VrBeyondOrdinaryProjectPage() {
             "A talk and demo exploring hybrid locomotion for richer VR interaction experiences.",
         },
       ]}
-      talks={[
-        {
-          title:
-            "HyperJumping in Virtual Vancouver: Combating Motion Sickness",
-          url: "https://doi.org/10.1145/3532834.3536211",
-        },
-      ]}
-      publications={[
-        {
-          title:
-            "Integrating continuous and teleporting VR locomotion into a seamless 'hyperjump' paradigm.",
-          authors:
-            "Adhikari, A., Zielasko, D., Aguilar, I., Bretin, A., Kruij, E., von der Heyde, M., & Riecke, B.E.",
-          venue: "IEEE TVCG, 29(12), 5265-5281 (2022).",
-          link: "https://ieeexplore.ieee.org/abstract/document/9894041/",
-        },
-      ]}
+      talks={talksAndResources}
+      publications={relatedPublications}
     >
       <section className="space-y-4">
         <h2 className="text-primary">Design Intent</h2>


### PR DESCRIPTION
Now, the projects pages and the publications page use the same data source so I only need to maintain publication.ts and projectResources.ts. This makes it easier to add new projects and publications in the future, and also ensures that the information is consistent across the site.

Closes #29